### PR TITLE
readme: Add link to test.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,4 +45,4 @@ You can force the badge to display zeroes by passing `true` as a third parameter
 $( '#inbox' ).badge( 0, 'top', true );
 ```
 
-See `test.html` for more examples.
+See [`test.html`](test.html) for more examples.


### PR DESCRIPTION
This works both in the repo browsing mode on github.com, as well as
via the generated static site at https://wikimedia.github.io/jquery-badge/

Fixes #2.